### PR TITLE
Create devcontainer.json for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,11 +4,16 @@
     "cpus": 4
   },
   "waitFor": "onCreateCommand",
-  "updateContentCommand": "python3 -m pip install -r .devcontainer/requirements.txt",
+  "updateContentCommand": "python -m pip install -r .devcontainer/requirements.txt",
   "postCreateCommand": "",
   "customizations": {
     "codespaces": {
-      "openFiles": []
+      "openFiles": [
+        "notebooks/llms/langchain/lc_vectorstore_conv_mem.ipynb",
+        "notebooks/llms/llamaindex/multi_doc_qa.ipynb",
+        "notebooks/text/white_house_speeches.ipynb",
+        "notebooks/vision/reverse_painting_search.ipynb"
+      ]
     },
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "hostRequirements": {
+    "cpus": 4
+  },
+  "waitFor": "onCreateCommand",
+  "updateContentCommand": "python3 -m pip install -r .devcontainer/requirements.txt",
+  "postCreateCommand": "",
+  "customizations": {
+    "codespaces": {
+      "openFiles": []
+    },
+    "vscode": {
+      "extensions": [
+        "ms-toolsai.jupyter",
+        "ms-python.python"
+      ]
+    }
+  }
+}

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,3 +1,4 @@
+ipykernel
 llama-index
 nltk
 milvus

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,9 +1,10 @@
 llama-index
 nltk
 milvus
-pymilvus=2.2.5
+pymilvus==2.2.5
 torch
-torchvision tqdm
+torchvision
+tqdm
 sentence-transformers
 gdown
 langchain

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -1,0 +1,12 @@
+llama-index
+nltk
+milvus
+pymilvus=2.2.5
+torch
+torchvision tqdm
+sentence-transformers
+gdown
+langchain
+openai
+python-dotenv
+requests


### PR DESCRIPTION
Add support to enable users to efficiently run a notebook directly in GitHub Codespaces. For the fastest experience (cached Python requirements), turn on [prebuilds](https://docs.github.com/en/codespaces/prebuilding-your-codespaces).